### PR TITLE
Add scripts for building deal.II as a static package

### DIFF
--- a/package-builders/dealii-ceed-bps-static.sh
+++ b/package-builders/dealii-ceed-bps-static.sh
@@ -1,0 +1,102 @@
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+# the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+# reserved. See files LICENSE and NOTICE for details.
+#
+# This file is part of CEED, a collection of benchmarks, miniapps, software
+# libraries and APIs for efficient high-order finite element and spectral
+# element discretizations for exascale applications. For more information and
+# source code availability see http://github.com/ceed.
+#
+# The CEED research is supported by the Exascale Computing Project (17-SC-20-SC)
+# a collaborative effort of two U.S. Department of Energy organizations (Office
+# of Science and the National Nuclear Security Administration) responsible for
+# the planning and preparation of a capable exascale ecosystem, including
+# software, applications, hardware, advanced system engineering and early
+# testbed platforms, in support of the nation's exascale computing imperative.
+
+# Clone and build the deal.II CEED benchmarks from:
+#    https://github.com/kronbichler/ceed_benchmarks_dealii
+
+if [[ -z "$pkg_sources_dir" ]]; then
+   echo "This script ($0) should not be called directly. Stop."
+   return 1
+fi
+if [[ -z "$OUT_DIR" ]]; then
+   echo "The variable 'OUT_DIR' is not set. Stop."
+   return 1
+fi
+pkg_src_dir="dealii-ceed-bps"
+DEALII_CEED_BPS_SOURCE_DIR="$pkg_sources_dir/$pkg_src_dir"
+pkg_bld_dir="$OUT_DIR/dealii-ceed-bps"
+DEALII_CEED_BPS_DIR="$pkg_bld_dir"
+pkg_var_prefix="dealii_ceed_bps_"
+pkg="deal.II-CEED-BPs"
+
+
+function dealii_ceed_bps_clone()
+{
+   pkg_repo_list=("git@github.com:kronbichler/ceed_benchmarks_dealii.git"
+                  "https://github.com/kronbichler/ceed_benchmarks_dealii.git")
+   pkg_git_branch="branch_dealii-8.5"
+   cd "$pkg_sources_dir" || return 1
+   if [[ -d "$pkg_src_dir" ]]; then
+      update_git_package
+      return
+   fi
+   for pkg_repo in "${pkg_repo_list[@]}"; do
+      echo "Cloning $pkg from $pkg_repo ..."
+      git clone "$pkg_repo" "$pkg_src_dir" && return 0
+   done
+   echo "Could not successfully clone $pkg. Stop."
+   return 1
+}
+
+
+function dealii_ceed_bps_build_aux()
+{
+   local bp_dir=
+   for bp_dir; do
+      mkdir -p "$pkg_bld_dir/$bp_dir" && \
+      cd "$pkg_bld_dir/$bp_dir" && \
+      cmake "$DEALII_CEED_BPS_SOURCE_DIR/$bp_dir" \
+         -DCMAKE_BUILD_TYPE="Release" \
+         -DCMAKE_VERBOSE_MAKEFILE=1 \
+         -DCMAKE_C_COMPILER="$MPICC" \
+         -DCMAKE_C_FLAGS_RELEASE="$CFLAGS" \
+         -DCMAKE_CXX_COMPILER="$MPICXX" \
+         -DCMAKE_CXX_FLAGS_RELEASE="$CFLAGS" \
+         -DCMAKE_CXX_FLAGS="$NATIVE_CFLAG" \
+         -DDEAL_II_DIR="$DEALII_DIR" && \
+      make -j $num_proc_build || return 1
+   done
+   return 0
+}
+
+
+function dealii_ceed_bps_build()
+{
+   if package_build_is_good; then
+      echo "Using successfully built $pkg from OUT_DIR."
+      return 0
+   elif [[ ! -d "$pkg_bld_dir" ]]; then
+      mkdir -p "$pkg_bld_dir"
+   fi
+   if [[ -z "$DEALII_DIR" ]]; then
+      echo "The required variable 'DEALII_DIR' is not set. Stop."
+      return 1
+   fi
+   echo "Building $pkg, sending output to ${pkg_bld_dir}_build.log ..." && {
+      dealii_ceed_bps_build_aux "bp1" "bp2" "bp3" "bp4" "bp5" "bp6"
+   } &> "${pkg_bld_dir}_build.log" || {
+      echo " ... building $pkg FAILED, see log for details."
+      return 1
+   }
+   echo "Build successful."
+   : > "${pkg_bld_dir}_build_successful"
+}
+
+
+function build_package()
+{
+   dealii_ceed_bps_clone && get_package_git_version && dealii_ceed_bps_build
+}

--- a/package-builders/dealii-static.sh
+++ b/package-builders/dealii-static.sh
@@ -1,0 +1,111 @@
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+# the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+# reserved. See files LICENSE and NOTICE for details.
+#
+# This file is part of CEED, a collection of benchmarks, miniapps, software
+# libraries and APIs for efficient high-order finite element and spectral
+# element discretizations for exascale applications. For more information and
+# source code availability see http://github.com/ceed.
+#
+# The CEED research is supported by the Exascale Computing Project (17-SC-20-SC)
+# a collaborative effort of two U.S. Department of Energy organizations (Office
+# of Science and the National Nuclear Security Administration) responsible for
+# the planning and preparation of a capable exascale ecosystem, including
+# software, applications, hardware, advanced system engineering and early
+# testbed platforms, in support of the nation's exascale computing imperative.
+
+# Clone and build the development version of deal.II.
+
+if [[ -z "$pkg_sources_dir" ]]; then
+   echo "This script ($0) should not be called directly. Stop."
+   return 1
+fi
+if [[ -z "$OUT_DIR" ]]; then
+   echo "The variable 'OUT_DIR' is not set. Stop."
+   return 1
+fi
+pkg_src_dir="dealii"
+DEALII_SOURCE_DIR="$pkg_sources_dir/$pkg_src_dir"
+pkg_bld_dir="$OUT_DIR/dealii"
+DEALII_DIR="$pkg_bld_dir"
+pkg_var_prefix="dealii_"
+pkg="deal.II"
+
+
+function dealii_clone()
+{
+   pkg_repo_list=("git@github.com:dealii/dealii.git"
+                  "https://github.com/dealii/dealii.git")
+   pkg_git_branch="dealii-8.5"
+   cd "$pkg_sources_dir" || return 1
+   if [[ -d "$pkg_src_dir" ]]; then
+      update_git_package
+      return
+   fi
+   for pkg_repo in "${pkg_repo_list[@]}"; do
+      echo "Cloning $pkg from $pkg_repo ..."
+      git clone "$pkg_repo" "$pkg_src_dir" && return 0
+   done
+   echo "Could not successfully clone $pkg. Stop."
+   return 1
+}
+
+
+function dealii_build()
+{
+   if package_build_is_good; then
+      echo "Using successfully built $pkg from OUT_DIR."
+      return 0
+   elif [[ ! -d "$pkg_bld_dir" ]]; then
+      mkdir -p "$pkg_bld_dir"
+   fi
+   if [[ -z "$P4EST_DIR" ]]; then
+      echo "The required variable 'P4EST_DIR' is not set. Stop."
+      return 1
+   fi
+   local LAPACK_CMAKE_OPTS=("-DDEAL_II_WITH_LAPACK=OFF")
+   if [[ -n "$LAPACK_LIB" ]]; then
+      LAPACK_CMAKE_OPTS=(
+         "-DDEAL_II_WITH_LAPACK=ON"
+         "-DLAPACK_LIBRARIES=$LAPACK_LIB")
+      array_union LDFLAGS "$LAPACK_LIB"
+   else
+      echo "${magenta}Warning: Building $pkg without LAPACK ...${none}"
+   fi
+   echo "Building $pkg, sending output to ${pkg_bld_dir}_build.log ..." && {
+      mkdir -p "$pkg_bld_dir"/build && cd "$pkg_bld_dir"/build && \
+      cmake "$DEALII_SOURCE_DIR" \
+         -DCMAKE_BUILD_TYPE="Release" \
+         -DCMAKE_VERBOSE_MAKEFILE=1 \
+         -DCMAKE_C_COMPILER="$MPICC" \
+         -DCMAKE_C_FLAGS_RELEASE="$CFLAGS" \
+         -DCMAKE_CXX_COMPILER="$MPICXX" \
+         -DCMAKE_CXX_FLAGS_RELEASE="$CFLAGS" \
+         -DDEAL_II_WITH_64BIT_INDICES="ON" \
+         -DDEAL_II_WITH_CXX11="OFF" \
+         -DCMAKE_CXX_FLAGS="$NATIVE_CFLAG" \
+         -DCMAKE_INSTALL_PREFIX="$pkg_bld_dir" \
+         -DDEAL_II_WITH_MPI="ON" \
+         "${LAPACK_CMAKE_OPTS[@]}" \
+         -DDEAL_II_WITH_P4EST="ON" \
+         -DP4EST_DIR="$P4EST_DIR" \
+         -DBUILD_SHARED_LIBS="OFF" \
+         -DCMAKE_DISABLE_FIND_PACKAGE_Boost="ON" \
+         -DDEAL_II_WITH_THREADS="OFF" && \
+      make -j $num_proc_build && \
+      make install && \
+      cd .. && rm -rf build
+   } &> "${pkg_bld_dir}_build.log" || {
+      echo " ... building $pkg FAILED, see log for details."
+      return 1
+   }
+   echo "Build successful."
+   print_variables "$pkg_var_prefix" \
+      CFLAGS LAPACK_LIB P4EST_DIR > "${pkg_bld_dir}_build_successful"
+}
+
+
+function build_package()
+{
+   dealii_clone && get_package_git_version && dealii_build
+}

--- a/package-builders/p4est-static.sh
+++ b/package-builders/p4est-static.sh
@@ -1,0 +1,98 @@
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+# the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+# reserved. See files LICENSE and NOTICE for details.
+#
+# This file is part of CEED, a collection of benchmarks, miniapps, software
+# libraries and APIs for efficient high-order finite element and spectral
+# element discretizations for exascale applications. For more information and
+# source code availability see http://github.com/ceed.
+#
+# The CEED research is supported by the Exascale Computing Project (17-SC-20-SC)
+# a collaborative effort of two U.S. Department of Energy organizations (Office
+# of Science and the National Nuclear Security Administration) responsible for
+# the planning and preparation of a capable exascale ecosystem, including
+# software, applications, hardware, advanced system engineering and early
+# testbed platforms, in support of the nation's exascale computing imperative.
+
+# Clone and build the development version of p4est.
+
+if [[ -z "$pkg_sources_dir" ]]; then
+   echo "This script ($0) should not be called directly. Stop."
+   return 1
+fi
+if [[ -z "$OUT_DIR" ]]; then
+   echo "The variable 'OUT_DIR' is not set. Stop."
+   return 1
+fi
+pkg_src_dir="p4est"
+P4EST_SOURCE_DIR="$pkg_sources_dir/$pkg_src_dir"
+pkg_bld_dir="$OUT_DIR/p4est"
+P4EST_DIR="$pkg_bld_dir"
+pkg_var_prefix="p4est_"
+pkg="p4est"
+
+
+function p4est_clone()
+{
+   pkg_repo_list=("git@github.com:cburstedde/p4est.git"
+                  "https://github.com/cburstedde/p4est.git")
+   pkg_git_branch="master"
+   cd "$pkg_sources_dir" || return 1
+   if [[ -d "$pkg_src_dir" ]]; then
+      update_git_package && \
+      git submodule init && git submodule update
+      return
+   fi
+   for pkg_repo in "${pkg_repo_list[@]}"; do
+      echo "Cloning $pkg from $pkg_repo ..."
+      git clone "$pkg_repo" "$pkg_src_dir" && \
+      cd "$pkg_src_dir" && git submodule init && git submodule update && \
+      return 0
+   done
+   echo "Could not successfully clone $pkg. Stop."
+   return 1
+}
+
+
+function p4est_build()
+{
+   if package_build_is_good; then
+      echo "Using successfully built $pkg from OUT_DIR."
+      return 0
+   elif [[ ! -d "$pkg_bld_dir" ]]; then
+      mkdir -p "$pkg_bld_dir"
+   fi
+   echo "Building $pkg, sending output to ${pkg_bld_dir}_build.log ..." && {
+      cd "$P4EST_SOURCE_DIR" && \
+      echo "--- bootstrap ----------------------------------------------" && \
+      ./bootstrap && \
+      echo "--- configure ----------------------------------------------" && \
+      mkdir -p "$pkg_bld_dir"/build && cd "$pkg_bld_dir"/build && \
+      $P4EST_SOURCE_DIR/configure \
+         --enable-mpi \
+         --disable-shared \
+         --disable-vtk-binary \
+         --without-blas \
+         --prefix="$pkg_bld_dir" \
+         CC="$MPICC" \
+         CFLAGS="$CFLAGS" \
+         CPPFLAGS="-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL" && \
+      echo "--- make ---------------------------------------------------" && \
+      make -j $num_proc_build && \
+      echo "--- make install -------------------------------------------" && \
+      make install && \
+      cd .. && rm -rf build
+   } &> "${pkg_bld_dir}_build.log" || {
+      echo " ... building $pkg FAILED, see log for details."
+      return 1
+   }
+   echo "Build successful."
+   print_variables "$pkg_var_prefix" \
+      CFLAGS > "${pkg_bld_dir}_build_successful"
+}
+
+
+function build_package()
+{
+   p4est_clone && get_package_git_version && p4est_build
+}


### PR DESCRIPTION
This is my first attempt to work with and modify these scripts, so I appreciate any comments. You guys have done an amazing job in centralizing this functionality to build things.

More specifically, this PR adds new "-static" files for the deal.II stack (p4est, dealii, dealii-ceed-bps) to build deal.II on the BG/Q machine that Thilina Rathnayake reported about yesterday. I disabled shared libraries from everything I build - at least I hope so -, switched to the old deal.II 8.5 release branch that does not yet require C++11 (which is a prerequisite to use the gcc-4.4 compiler stack for IBM target as on that system), and enabled 64-bit integers because I assume we might go beyond 4b unknowns on 512 nodes and there should not be any performance penalty.