### PR TITLE
Ensure to build all 6 bp problems with deal.II

### DIFF
--- a/package-builders/dealii-ceed-bps.sh
+++ b/package-builders/dealii-ceed-bps.sh
@@ -86,7 +86,7 @@ function dealii_ceed_bps_build()
       return 1
    fi
    echo "Building $pkg, sending output to ${pkg_bld_dir}_build.log ..." && {
-      dealii_ceed_bps_build_aux "bp1" "bp2"
+      dealii_ceed_bps_build_aux "bp1" "bp2" "bp3" "bp4" "bp5" "bp6"
    } &> "${pkg_bld_dir}_build.log" || {
       echo " ... building $pkg FAILED, see log for details."
       return 1

--- a/package-builders/p4est.sh
+++ b/package-builders/p4est.sh
@@ -40,7 +40,7 @@ function p4est_clone()
    cd "$pkg_sources_dir" || return 1
    if [[ -d "$pkg_src_dir" ]]; then
       update_git_package && \
-      cd "$pkg_src_dir" && git submodule init && git submodule update
+      git submodule init && git submodule update
       return
    fi
    for pkg_repo in "${pkg_repo_list[@]}"; do


### PR DESCRIPTION
When trying to build the dealii BP problems on Linux (with the standard configuration) I realized that we do not build all 6 cases. This PR enables them.

Furthermore, I observed a (in my opinion spurious) directory change into a directory `p4est` that does not exist because we are already there at this point.