### PR TITLE
[WIP] AmgX adjustments for benchmarking

### DIFF
--- a/postprocess-base.py
+++ b/postprocess-base.py
@@ -96,9 +96,11 @@ while True:
          state=2
       elif 'setup' in line: 
          data['amg-setup'] = float(line.split()[1])
+      #Used when using AmgX as a solver
+      elif 'solve(per iteration)' in line:
+         data['time-per-iter'] = float(line.split()[2])
       elif 'Total iterations' in line: 
          data['iterations'] = float(line.split()[2])
-         print(line.split())
       elif '"DOFs/sec" in CG' in line:
          # out.write(lnfmt%i+': %s'%line)
          data['cg-iteration-dps']=1e6*float(line.split(' ')[3])

--- a/postprocess-base.py
+++ b/postprocess-base.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+# the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+# reserved. See files LICENSE and NOTICE for details.
+#
+# This file is part of CEED, a collection of benchmarks, miniapps, software
+# libraries and APIs for efficient high-order finite element and spectral
+# element discretizations for exascale applications. For more information and
+# source code availability see http://github.com/ceed.
+#
+# The CEED research is supportted by the Exascale Computing Project
+# (17-SC-20-SC), a collaborative effort of two U.S. Department of Energy
+# organizations (Office of Science and the National Nuclear Security
+# Administration) responsible for the planning and preparation of a capable
+# exascale ecosystem, including software, applications, hardware, advanced
+# system engineering and early testbed platforms, in support of the nation's
+# exascale computing imperative.
+
+from sys import stdout as out
+import fileinput
+import pprint
+
+#####   Read all input files specified on the command line, or stdin and parse
+#####   the content, storing it as a list of dictionaries - one dictionary for
+#####   each test run.
+
+it=fileinput.input()
+state=0
+line=''
+i=0
+mesh_p=1
+config='unknown'
+compiler='unknown'
+test='unknown'
+num_procs=0
+num_procs_node=0
+lnfmt='%05i'
+data={}
+runs=[]
+
+while True:
+   ##
+   if state%2==0:
+      ##
+      try:
+         line=it.next()
+         i=i+1
+      except StopIteration:
+         break
+      state=state+1
+      ##
+   elif state==1:
+      ##
+      state=0
+      if 'Reading configuration' in line:
+         ##
+         ## This is the beginning of a new file.
+         ##
+         # out.write('\n'+lnfmt%i+': %s'%line)
+         config=line.split()[2]
+         num_procs=0
+         num_procs_node=0
+      elif 'Setting up compiler' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         compiler=line.split()[3]
+      elif 'Reading test file: ' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         test=line.strip().split('Reading test file: ',1)[-1]
+      elif 'Running the tests using a total of' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         num_procs=int(line.split('a total of ',1)[1].split(None,1)[0])
+      elif 'tasks per node' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         num_procs_node=int(line.split(' tasks per',1)[0].rsplit(None,1)[1])
+      elif line == 'Options used:\n':
+         ##
+         ## This is the beginning of a new run.
+         ##
+         if 'cg-iteration-dps' in data:
+            runs.append(data)
+            # print
+            # pprint.pprint(data)
+         data={}
+         data['file']=fileinput.filename()
+         data['config']=config
+         data['compiler']=compiler
+         data['test']=test
+         data['num-procs']=num_procs
+         data['num-procs-node']=num_procs_node
+         data['mesh-order']=mesh_p
+         data['code']="MFEM"
+         test_=test.rsplit('/',1)[-1]
+         data['case']='scalar' if (('bp1' in test_) or ('bp3' in test_) or
+                                   ('bp5' in test_)) else 'vector'
+         # out.write('\n'+lnfmt%i+': %s'%line)
+         # out.write('*'*len(lnfmt%i)+':    --mesh-p %i\n'%mesh_p)
+         state=2
+      elif 'setup' in line: 
+         data['amg-setup'] = float(line.split()[1])
+      elif 'Total iterations' in line: 
+         data['iterations'] = float(line.split()[2])
+         print(line.split())
+      elif '"DOFs/sec" in CG' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         data['cg-iteration-dps']=1e6*float(line.split(' ')[3])
+      elif 'Number of finite element unknowns' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         data['num-unknowns']=long(line.rsplit(None,1)[1])
+      elif 'Number of qudrature points per element' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         data['quadrature-pts']=int(line.split(' = ',1)[1])
+      elif 'Total number of elements:' in line:
+         # out.write(lnfmt%i+': %s'%line)
+         data['num-elem']=int(line.rsplit(None,1)[1])
+      ##
+   elif state==3:
+      ##
+      if line[:5] == '   --':
+         # out.write(lnfmt%i+': %s'%line)
+         state=2
+         opt=line[5:].strip().split(' ',1)
+         if opt[0] in ('order'):
+            data[opt[0]]=int(opt[1])
+         elif opt[0] in ('device'):
+            data['mfem-device']=opt[1]
+      else:
+         state=1
+
+if 'cg-iteration-dps' in data:
+   runs.append(data)
+   # print
+   # pprint.pprint(data)
+for run in runs:
+   if not 'quadrature-pts' in run:
+      run['quadrature-pts']=0
+# print
+# print
+# pprint.pprint(runs)
+
+print 'Number of test runs read: %i'%len(runs)

--- a/postprocess-table.py
+++ b/postprocess-table.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+# the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+# reserved. See files LICENSE and NOTICE for details.
+#
+# This file is part of CEED, a collection of benchmarks, miniapps, software
+# libraries and APIs for efficient high-order finite element and spectral
+# element discretizations for exascale applications. For more information and
+# source code availability see http://github.com/ceed.
+#
+# The CEED research is supportted by the Exascale Computing Project
+# (17-SC-20-SC), a collaborative effort of two U.S. Department of Energy
+# organizations (Office of Science and the National Nuclear Security
+# Administration) responsible for the planning and preparation of a capable
+# exascale ecosystem, including software, applications, hardware, advanced
+# system engineering and early testbed platforms, in support of the nation's
+# exascale computing imperative.
+
+
+#####   Load the data
+execfile('postprocess-base.py')
+
+
+#####   Sample data output
+
+set1=sorted(
+   [(run['mfem-device'],
+     run['order'],run['compiler'],run['num-procs'],
+     run['num-unknowns'],run['iterations'], run['amg-setup'], run['cg-iteration-dps']/1e6)
+    for run in runs])
+
+out.write('''\
+    mfem   |    |  comp  |     |number of|      |  amg       | cg-iter dps
+   device  |  p |  iler  |  np |unknowns | iter |  setup     |   millions
+-----------+----+--------+-----+----------+----+------+-------------+---------
+''')
+line_fmt=' %9s | %2i | %6s | %3i | %3i  | %3i | %11.6f |%11.6f\n'
+for run in set1:
+   out.write(line_fmt%run)

--- a/postprocess-table.py
+++ b/postprocess-table.py
@@ -25,14 +25,15 @@ execfile('postprocess-base.py')
 set1=sorted(
    [(run['mfem-device'],
      run['order'],run['compiler'],run['num-procs'],
-     run['num-unknowns'],run['iterations'], run['amg-setup'], run['cg-iteration-dps']/1e6)
+     run['num-unknowns'],run['amg-setup'], run['iterations'],
+     run['time-per-iter'], run['cg-iteration-dps']/1e6)
     for run in runs])
 
 out.write('''\
-    mfem   |    |  comp  |     |number of|      |  amg       | cg-iter dps
-   device  |  p |  iler  |  np |unknowns | iter |  setup     |   millions
------------+----+--------+-----+----------+----+------+-------------+---------
+    mfem   |    |  comp  |     |number of |  amg       |         |               | cg-iter dps
+   device  |  p |  iler  |  np |unknowns  |  setup     | No Iter | time-per-iter |   millions
+-----------+----+--------+-----+---------+-------------+---------+---------------+-------------
 ''')
-line_fmt=' %9s | %2i | %6s | %3i | %3i  | %3i | %11.6f |%11.6f\n'
+line_fmt=' %9s | %2i | %6s | %3i | %6i  | %11.6f | %7i | %11.6f |%11.6f\n'
 for run in set1:
    out.write(line_fmt%run)

--- a/tests/mfem_amgx/ex1p_amgx_precon.cpp
+++ b/tests/mfem_amgx/ex1p_amgx_precon.cpp
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
    amgx_config = amgx_config + " }\n" + "}\n";
 
    AmgXSolver *prec = new AmgXSolver;
-   prec->ConfigureAs(AmgXSolver::PRECONDITIONER);
+   prec->SetConvergenceCheck(false);
    prec->ReadParameters(amgx_config, AmgXSolver::INTERNAL);
    prec->InitExclusiveGPU(MPI_COMM_WORLD);
 

--- a/tests/mfem_amgx/ex1p_amgx_precon.sh
+++ b/tests/mfem_amgx/ex1p_amgx_precon.sh
@@ -30,7 +30,7 @@ function build_tests()
 
 function run_tests()
 {
-   local test_name="ex1p_amgx"
+   local test_name="ex1p_amgx_precon"
    set_mpi_options
    # 'min_p' can be set on the command line
    local l_min_p=${min_p:-1}

--- a/tests/mfem_amgx/ex1p_amgx_solver.cpp
+++ b/tests/mfem_amgx/ex1p_amgx_solver.cpp
@@ -170,14 +170,14 @@ int main(int argc, char *argv[])
                     "     \"interpolator\": \"D2\", \n"
                     "     \"max_row_sum\" : 0.9, \n"
                     "     \"strength_threshold\" : 0.25, \n"
-                    "     \"max_iters\": 0, \n"
+                    "     \"max_iters\": 2, \n"
                     "     \"scope\": \"amg\", \n"
                     "     \"max_levels\": 100, \n"
                     "     \"cycle\": \"V\", \n"
                     "     \"postsweeps\": 1 \n"
                     "    }, \n"
                     "  \"solver\": \"PCG\", \n"
-                    "  \"max_iters\": 0, \n"
+                    "  \"max_iters\": 100, \n"
                     "  \"convergence\": \"RELATIVE_MAX\", \n"
                     "  \"scope\": \"main\", \n"
                     "  \"tolerance\": 1e-12, \n"
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
    // Print timing results.
    if (myid == 0)
    {
-      int cg_iter = amgx->GetNumIterations()-1;
+      int cg_iter = amgx->GetNumIterations();
       // Note: In the pcg algorithm, the number of operator Mult() calls is
       //       N_iter and the number of preconditioner Mult() calls is N_iter+1.
       cout << '\n'

--- a/tests/mfem_amgx/ex1p_amgx_solver.cpp
+++ b/tests/mfem_amgx/ex1p_amgx_solver.cpp
@@ -170,14 +170,14 @@ int main(int argc, char *argv[])
                     "     \"interpolator\": \"D2\", \n"
                     "     \"max_row_sum\" : 0.9, \n"
                     "     \"strength_threshold\" : 0.25, \n"
-                    "     \"max_iters\": 2, \n"
+                    "     \"max_iters\": 0, \n"
                     "     \"scope\": \"amg\", \n"
                     "     \"max_levels\": 100, \n"
                     "     \"cycle\": \"V\", \n"
                     "     \"postsweeps\": 1 \n"
                     "    }, \n"
                     "  \"solver\": \"PCG\", \n"
-                    "  \"max_iters\": 100, \n"
+                    "  \"max_iters\": 0, \n"
                     "  \"convergence\": \"RELATIVE_MAX\", \n"
                     "  \"scope\": \"main\", \n"
                     "  \"tolerance\": 1e-12, \n"
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
     amgx_config = amgx_config + "   } \n" + "} \n";
       
    AmgXSolver *amgx = new AmgXSolver;
-   amgx->ConfigureAs(AmgXSolver::SOLVER);
+   amgx->SetConvergenceCheck(true);
    amgx->ReadParameters(amgx_config, AmgXSolver::INTERNAL);
    amgx->InitExclusiveGPU(MPI_COMM_WORLD);
 
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
    // Print timing results.
    if (myid == 0)
    {
-      int cg_iter = amgx->GetNumIterations();
+      int cg_iter = amgx->GetNumIterations()-1;
       // Note: In the pcg algorithm, the number of operator Mult() calls is
       //       N_iter and the number of preconditioner Mult() calls is N_iter+1.
       cout << '\n'


### PR DESCRIPTION
This PR makes adjustments to python scripts to set apart amg setup time, no of iterations, and time-per-iteration.  
Still a work in progress, but logging what I see. 

```
    mfem   |    |  comp  |     |number of |  amg       |         |               | cg-iter dps
   device  |  p |  iler  |  np |unknowns  |  setup     | No Iter | time-per-iter |   millions
-----------+----+--------+-----+---------+-------------+---------+---------------+-------------
      cuda |  1 |    xlc |   4 |     18  |    0.000468 |       1 |    0.000000 |   0.033255
      cuda |  1 |    xlc |   4 |     27  |    0.000438 |       2 |    0.001043 |   0.038509
      cuda |  1 |    xlc |   4 |     45  |    0.000471 |       3 |    0.000981 |   0.057660
      cuda |  1 |    xlc |   4 |     75  |    0.000491 |       7 |    0.000940 |   0.087167
      cuda |  1 |    xlc |   4 |    125  |    0.000497 |       8 |    0.000969 |   0.139263
      cuda |  1 |    xlc |   4 |    225  |    0.000605 |      11 |    0.000931 |   0.255691
      cuda |  1 |    xlc |   4 |    405  |    0.000924 |      11 |    0.000950 |   0.450530
      cuda |  1 |    xlc |   4 |    729  |    0.004724 |      11 |    0.001284 |   0.607944
      cuda |  1 |    xlc |   4 |   1377  |    0.005715 |      15 |    0.000986 |   1.453810
      cuda |  1 |    xlc |   4 |   2601  |    0.009194 |      16 |    0.001372 |   1.984690
      cuda |  1 |    xlc |   4 |   4913  |    0.015172 |      16 |    0.001390 |   3.707380
      cuda |  1 |    xlc |   4 |   9537  |    0.036640 |      22 |    0.001878 |   5.273700
      cuda |  1 |    xlc |   4 |  18513  |    0.039395 |      14 |    0.001856 |  10.590700
      cuda |  1 |    xlc |   4 |  35937  |    0.052646 |      14 |    0.002336 |  16.330200
      cuda |  1 |    xlc |   4 |  70785  |    0.097023 |      27 |    0.003166 |  23.070800
      cuda |  1 |    xlc |   4 | 139425  |    0.099476 |      14 |    0.002876 |  51.618500
      cuda |  1 |    xlc |   4 | 274625  |    0.140822 |      12 |    0.003380 |  87.708900
      cuda |  1 |    xlc |   4 | 545025  |    0.381351 |      31 |    0.004954 | 113.373000
      cuda |  1 |    xlc |   4 | 1081665  |    0.357588 |      14 |    0.005256 | 220.212000
      cuda |  1 |    xlc |   4 | 2146689  |    0.749115 |      11 |    0.008046 | 291.702000
      cuda |  1 |    xlc |   4 | 4276737  |    2.608220 |      37 |    0.019247 | 228.178000
      cuda |  1 |    xlc |   4 | 8520321  |    2.131120 |      15 |    0.021306 | 427.370000
```