### PR TITLE
Performance comparisons: nc mesh vs conf. mesh

### DIFF
--- a/machine-configs/lassen.sh
+++ b/machine-configs/lassen.sh
@@ -21,7 +21,7 @@ function setup_xlc()
    MPIF77=mpixlf
    mpi_info_flag="-qversion=verbose"
 
-   CFLAGS="-O2 -qmaxmem=-1 -qarch=auto -qcache=auto -qtune=auto"
+   CFLAGS="-O2"
    # CFLAGS="-O3 -qarch=auto -qcache=auto -qhot -qtune=auto"
    # CFLAGS+=" -qipa=threads"
 
@@ -44,10 +44,12 @@ function setup_gcc()
 
    MPICC=mpigcc
    MPICXX=mpig++
+   which $MPICXX
+   $MPICXX --version
    MPIF77=mpigfortran
    mpi_info_flag="--version"
 
-   CFLAGS="-O3 -mcpu=native -mtune=native"
+   CFLAGS="-O3"
    FFLAGS="$CFLAGS"
    TEST_EXTRA_CFLAGS=""
    # TEST_EXTRA_CFLAGS+=" -std=c++11 -fdump-tree-optimized-blocks"

--- a/tests/mfem_ex1/ex1.cpp
+++ b/tests/mfem_ex1/ex1.cpp
@@ -81,6 +81,9 @@ int main(int argc, char *argv[])
    Array<int> nxyz;
    Mesh *mesh = make_mesh(myid, num_procs, dim, level, par_ref_levels, nxyz);
 
+   //Go through NC mesh machinery
+   mesh->EnsureNCMesh();
+
    // 5. Refine the serial mesh on all processors to increase the resolution. In
    //    this example we do 'ref_levels' of uniform refinement. We choose
    //    'ref_levels' to be the largest number that gives a final mesh with no

--- a/tests/mfem_ex1/ex1.sh
+++ b/tests/mfem_ex1/ex1.sh
@@ -39,7 +39,7 @@ function run_tests()
    # 'max_dofs_proc' can be set on the command line
    local l_max_dofs_proc=${max_dofs_proc:-4200000}
    # 'mfem_devs' can be set on the command line
-   local l_mfem_devs=(${mfem_devs:-cpu})
+   local l_mfem_devs=(${mfem_devs:-cuda})
    local dim=3
    local args=
    for dev in ${l_mfem_devs[@]}; do
@@ -92,6 +92,6 @@ libceed_branch=${libceed_branch:-master}
 # Only with HIP
 #packages="hip metis hypre mfem-hip"
 
-packages=${packages:-metis hypre mfem}
+packages=${packages:-metis cuda hypre mfem}
 
 test_required_packages=${packages}


### PR DESCRIPTION
Folks, we seem to loose quite a bit of performance when going the  nc-mesh machinery.

This PR will generate the data for the plot below: 
 
![nc-mesh](https://user-images.githubusercontent.com/4537104/169865240-1f2f8f79-7f13-47a2-b164-eeccadb4dccd.png)


when using a conforming mesh, we see the following performance: 

![Screen Shot 2022-05-23 at 9 23 46 AM](https://user-images.githubusercontent.com/4537104/169865289-1814828b-d7a7-49ee-a0e0-974ac8786dcb.png)


With hypre branch: [parcsr_local_trans](https://github.com/hypre-space/hypre/tree/parcsr_local_trans)
+ a change in  ex1

![parcsr_local_trans png](https://user-images.githubusercontent.com/4537104/170798649-f1dca103-a8c9-41ae-9b17-819086f0072d.png)



